### PR TITLE
BTAT-9929 Increased coverage to 100%, tweaked error scenarios

### DIFF
--- a/app/controllers/SetupSchemaController.scala
+++ b/app/controllers/SetupSchemaController.scala
@@ -38,7 +38,7 @@ class SetupSchemaController @Inject()(schemaRepository: SchemaRepository,
         })
       }
     ).recover {
-      case _ => BadRequest("Error Parsing Json SchemaModel")
+      case ex => InternalServerError(s"Schema could not be added due to exception: ${ex.getMessage}")
     }
   }
 

--- a/app/utils/SchemaValidation.scala
+++ b/app/utils/SchemaValidation.scala
@@ -40,7 +40,7 @@ class SchemaValidation @Inject()(repository: SchemaRepository) extends LoggerUti
       val schemaJson: JsonNode = schemaMapper.readTree(schemaParser)
       JsonSchemaFactory.byDefault().getJsonSchema(schemaJson)
     } recover {
-      case ex => throw new Exception("Schema could not be retrieved/found in MongoDB")
+      case ex => throw new Exception(s"Schema could not be retrieved due to exception: ${ex.getMessage}")
     }
   }
 
@@ -81,7 +81,7 @@ class SchemaValidation @Inject()(repository: SchemaRepository) extends LoggerUti
         true
       }
     } recover {
-      case ex => throw new Exception("Schema could not be retrieved/found in MongoDB")
+      case ex => throw new Exception(s"Schema could not be retrieved due to exception: ${ex.getMessage}")
     }
   }
 

--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ val appName = "vat-subscription-dynamic-stub"
 
 val compile: Seq[ModuleID] = Seq(ws,
   "uk.gov.hmrc"     %% "simple-reactivemongo"       % "8.0.0-play-28",
-  "uk.gov.hmrc"     %% "bootstrap-backend-play-28"  % "5.15.0",
+  "uk.gov.hmrc"     %% "bootstrap-backend-play-28"  % "5.16.0",
   "com.github.fge"  %  "json-schema-validator"      % "2.2.14"
 )
 
@@ -51,24 +51,12 @@ lazy val scoverageSettings = {
   Seq(
     ScoverageKeys.coverageExcludedPackages := "<empty>;" +
       ".*Reverse.*;" +
-      "models/.data/..*;" +
-      "filters.*;" +
-      ".handlers.*;" +
-      "components.*;" +
-      ".*BuildInfo.*;" +
-      ".*FrontendAuditConnector.*;" +
       ".*Routes.*;" +
-      "views.html.templates.*;" +
-      "views.html.feedback.*;" +
       "config.*;" +
-      "controllers.feedback.*;" +
       "app.*;" +
       "prod.*;" +
-      "config.*;" +
-      "com.*;" +
-      "testOnly.*;" +
-      "\"",
-    ScoverageKeys.coverageMinimumStmtTotal := 90,
+      "config.*;",
+    ScoverageKeys.coverageMinimumStmtTotal := 95,
     ScoverageKeys.coverageFailOnMinimum := false,
     ScoverageKeys.coverageHighlighting := true
   )

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -25,7 +25,7 @@ play.application.loader = "uk.gov.hmrc.play.bootstrap.ApplicationLoader"
 # ~~~~
 # Additional play modules can be added here
 play.modules.enabled += "play.modules.reactivemongo.ReactiveMongoHmrcModule"
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuditModule"
+play.modules.enabled += "uk.gov.hmrc.play.audit.AuditModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.backend.BackendModule"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -19,7 +19,7 @@ resolvers += Resolver.url("HMRC Private Sbt Plugin Releases", url("https://artef
 resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefacts.tax.service.gov.uk/maven2")
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.5.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.6.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 

--- a/test/mocks/MockSchemaRepository.scala
+++ b/test/mocks/MockSchemaRepository.scala
@@ -16,7 +16,6 @@
 
 package mocks
 
-import models.SchemaModel
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.mockito.stubbing.OngoingStubbing
@@ -28,8 +27,10 @@ import scala.concurrent.Future
 
 trait MockSchemaRepository extends TestSupport {
 
-  val successWriteResult = UpdateWriteResult(ok = true, n = 1, nModified = 1, upserted = Seq(), writeErrors = Seq(), None, None, None)
-  val errorWriteResult = UpdateWriteResult(ok = false, n = 1, nModified = 0, upserted = Seq(), writeErrors = Seq(WriteError(1,1,"Error")), None, None, None)
+  val successWriteResult: UpdateWriteResult =
+    UpdateWriteResult(ok = true, n = 1, nModified = 1, upserted = Seq(), writeErrors = Seq(), None, None, None)
+  val errorWriteResult: UpdateWriteResult =
+    UpdateWriteResult(ok = false, n = 1, nModified = 0, upserted = Seq(), writeErrors = Seq(WriteError(1,1,"Error")), None, None, None)
 
   lazy val mockSchemaRepository: SchemaRepository = new SchemaRepository(rmc) {
     override lazy val repository: SchemaRepositoryBase = mock[SchemaRepositoryBase]
@@ -40,8 +41,8 @@ trait MockSchemaRepository extends TestSupport {
     reset(mockSchemaRepository.repository)
   }
 
-  def setupMockAddSchema(model: SchemaModel)(response: WriteResult): OngoingStubbing[Future[WriteResult]] =
-    when(mockSchemaRepository.repository.addEntry(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(Future.successful(response))
+  def setupMockAddSchema(response: Future[WriteResult]): OngoingStubbing[Future[WriteResult]] =
+    when(mockSchemaRepository.repository.addEntry(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(response)
 
   def setupMockRemoveSchema(id: String)(response: WriteResult): OngoingStubbing[Future[WriteResult]] =
     when(mockSchemaRepository.repository.removeById(ArgumentMatchers.eq(id))(ArgumentMatchers.any())).thenReturn(Future.successful(response))


### PR DESCRIPTION
Filling in the gaps in the tests helped me to gain a better understanding of the individual error scenarios in the affected functions. As a result I have tweaked two error responses in the app to better reflect what the behaviour should be, and to give more helpful information for when these unexpected errors occur.

I've also removed a bunch of pointless scoverage excludes and bumped up the minimum coverage to 95%. As this is a stub service it will not fail the build if the coverage goes below this; it's purely a recommended guideline.

As usual let me know if you disagree with any changes.