### PR TITLE
BTAT-11458 Upgraded hmrc-mongo and added TTL to repositories

### DIFF
--- a/app/common/Constants.scala
+++ b/app/common/Constants.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+object Constants {
+
+  val timeToLiveInSeconds = 2628000     // one month
+}

--- a/app/repositories/DataRepository.scala
+++ b/app/repositories/DataRepository.scala
@@ -16,17 +16,25 @@
 
 package repositories
 
-import models._
+import common.Constants
+import models.DataModel
+import org.mongodb.scala.model.{IndexModel, IndexOptions, Indexes}
 import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
+
+import java.util.concurrent.TimeUnit
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext
 
 @Singleton
-class DataRepository @Inject()(mongo: MongoComponent)(implicit ec: ExecutionContext
-) extends PlayMongoRepository[DataModel](
+class DataRepository @Inject()(mongo: MongoComponent)
+                              (implicit ec: ExecutionContext) extends PlayMongoRepository[DataModel](
   mongoComponent = mongo,
   collectionName = "data",
   domainFormat   = DataModel.formats,
-  indexes        = Seq()
+  indexes        = Seq(IndexModel(
+    Indexes.ascending("creationTimestamp"),
+    IndexOptions().name("expiry").expireAfter(Constants.timeToLiveInSeconds, TimeUnit.SECONDS)
+  )),
+  replaceIndexes = true
 )

--- a/app/repositories/SchemaRepository.scala
+++ b/app/repositories/SchemaRepository.scala
@@ -16,19 +16,27 @@
 
 package repositories
 
-import javax.inject.{Inject, Singleton}
+import common.Constants
 import models.SchemaModel
-import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
+import org.mongodb.scala.model.{IndexModel, IndexOptions, Indexes}
 import uk.gov.hmrc.mongo.MongoComponent
+import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
+
+import java.util.concurrent.TimeUnit
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext
 
 @Singleton
-class SchemaRepository @Inject()(mongo: MongoComponent)(implicit ec: ExecutionContext
-) extends PlayMongoRepository[SchemaModel](
+class SchemaRepository @Inject()(mongo: MongoComponent)
+                                (implicit ec: ExecutionContext) extends PlayMongoRepository[SchemaModel](
   mongoComponent = mongo,
   collectionName = "schemas",
   domainFormat   = SchemaModel.formats,
-  indexes        = Seq()
+  indexes        = Seq(IndexModel(
+    Indexes.ascending("creationTimestamp"),
+    IndexOptions().name("expiry").expireAfter(Constants.timeToLiveInSeconds, TimeUnit.SECONDS)
+  )),
+  replaceIndexes = true
 )
 
 

--- a/build.sbt
+++ b/build.sbt
@@ -16,31 +16,25 @@
 
 import sbt._
 import uk.gov.hmrc.DefaultBuildSettings._
-import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin._
-import play.core.PlayVersion
 import play.sbt.routes.RoutesKeys
 import sbt.Tests.{Group, SubProcess}
 
 val appName = "vat-subscription-dynamic-stub"
 
 val compile: Seq[ModuleID] = Seq(ws,
-  "uk.gov.hmrc.mongo"  %% "hmrc-mongo-play-28"        % "0.74.0",
-  "uk.gov.hmrc"        %% "bootstrap-backend-play-28" % "7.12.0",
+  "uk.gov.hmrc.mongo"  %% "hmrc-mongo-play-28"        % "1.1.0",
+  "uk.gov.hmrc"        %% "bootstrap-backend-play-28" % "7.15.0",
   "com.github.fge"     %  "json-schema-validator"     % "2.2.14",
   "com.github.bjansen" %  "swagger-schema-validator"  % "1.0.0"
 )
 
 def test(scope: String = "test,it"): Seq[ModuleID] = Seq(
-  "uk.gov.hmrc"            %% "bootstrap-test-play-28"    % "7.12.0" % scope,
-  "org.scalamock"          %% "scalamock"                 % "5.2.0"  % scope,
-  "uk.gov.hmrc.mongo"       %% "hmrc-mongo-test-play-28"  % "0.74.0" % scope
+  "uk.gov.hmrc"            %% "bootstrap-test-play-28"   % "7.15.0" % scope,
+  "org.scalamock"          %% "scalamock"                % "5.2.0"  % scope,
+  "uk.gov.hmrc.mongo"      %% "hmrc-mongo-test-play-28"  % "1.1.0"  % scope
 )
 
 lazy val appDependencies: Seq[ModuleID] = compile ++ test()
-lazy val plugins: Seq[Plugins] = Seq.empty
-lazy val playSettings: Seq[Setting[_]] = Seq.empty
-
-RoutesKeys.routesImport := Seq.empty
 
 lazy val scoverageSettings = {
   import scoverage.ScoverageKeys
@@ -59,17 +53,16 @@ lazy val scoverageSettings = {
 }
 
 lazy val microservice = Project(appName, file("."))
-  .enablePlugins(Seq(play.sbt.PlayScala, SbtDistributablesPlugin) ++ plugins: _*)
-  .settings(playSettings: _*)
+  .enablePlugins(play.sbt.PlayScala, SbtDistributablesPlugin)
   .settings(scalaSettings: _*)
-  .settings(publishingSettings: _*)
   .settings(scoverageSettings: _*)
   .settings(defaultSettings(): _*)
   .settings(
     majorVersion := 0,
     scalaVersion := "2.13.8",
     libraryDependencies ++= appDependencies,
-    retrieveManaged := true
+    retrieveManaged := true,
+    RoutesKeys.routesImport := Seq.empty
   )
   .settings(PlayKeys.playDefaultPort := 9156)
   .configs(IntegrationTest)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -18,9 +18,6 @@ include "backend.conf"
 
 appName = vat-subscription-dynamic-stub
 
-# An ApplicationLoader that uses Guice to bootstrap the application.
-play.application.loader = "uk.gov.hmrc.play.bootstrap.ApplicationLoader"
-
 # Play Modules
 # ~~~~
 # Additional play modules can be added here
@@ -34,11 +31,6 @@ play.modules.enabled += "uk.gov.hmrc.play.bootstrap.backend.BackendModule"
 # ~~~~
 # Additional play filters can be added here
 play.filters.disabled += play.filters.hosts.AllowedHostsFilter
-
-# Global request handler
-# ~~~~
-# Set to the object handler for migrated 2.3 services
-play.http.requestHandler = "uk.gov.hmrc.play.bootstrap.http.RequestHandler"
 
 # Session Timeout
 # ~~~~

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -19,11 +19,11 @@ resolvers += Resolver.url("HMRC Private Sbt Plugin Releases", url("https://artef
 resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefacts.tax.service.gov.uk/maven2")
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.8.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.9.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.2.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.18")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.19")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.3")
 

--- a/test/controllers/SetupSchemaControllerSpec.scala
+++ b/test/controllers/SetupSchemaControllerSpec.scala
@@ -52,8 +52,8 @@ class SetupSchemaControllerSpec extends TestSupport with MockSchemaService {
         status(result) shouldBe Status.OK
       }
 
-      s"return a response body of 'Successfully added Schema: ${Json.toJson(successModel)}'" in {
-        contentAsString(result) shouldBe s"Successfully added Schema: ${Json.toJson(successModel)}"
+      "return a response body that contains a confirmation" in {
+        contentAsString(result) should include("Successfully added Schema")
       }
     }
 

--- a/test/repositories/DataRepositorySpec.scala
+++ b/test/repositories/DataRepositorySpec.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package repositories
+
+import common.Constants
+import models.DataModel
+import org.mongodb.scala.bson.{BsonInt64, BsonString}
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
+import testUtils.TestSupport
+import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
+
+class DataRepositorySpec extends TestSupport with DefaultPlayMongoRepositorySupport[DataModel] {
+
+  override lazy val repository = new DataRepository(mongoComponent)
+
+  "The DataRepository" should {
+
+    "have a TTL index on the creationTimestamp field, with an expiry time set by the Constants object" in {
+      val indexes = {
+        await(repository.ensureIndexes())
+        await(repository.collection.listIndexes().toFuture())
+      }
+      val ttlIndex = indexes.find(_.get("name").contains(BsonString("expiry")))
+
+      ttlIndex.get("key").toString shouldBe """{"creationTimestamp": 1}"""
+      ttlIndex.get("expireAfterSeconds") shouldBe BsonInt64(Constants.timeToLiveInSeconds)
+    }
+  }
+}

--- a/test/repositories/SchemaRepositorySpec.scala
+++ b/test/repositories/SchemaRepositorySpec.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package repositories
+
+import common.Constants
+import models.SchemaModel
+import org.mongodb.scala.bson.{BsonInt64, BsonString}
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
+import testUtils.TestSupport
+import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
+
+class SchemaRepositorySpec extends TestSupport with DefaultPlayMongoRepositorySupport[SchemaModel] {
+
+  override lazy val repository = new SchemaRepository(mongoComponent)
+
+  "The SchemaRepository" should {
+
+    "have a TTL index on the creationTimestamp field, with an expiry time set by the Constants object" in {
+      val indexes = {
+        await(repository.ensureIndexes())
+        await(repository.collection.listIndexes().toFuture())
+      }
+      val ttlIndex = indexes.find(_.get("name").contains(BsonString("expiry")))
+
+      ttlIndex.get("key").toString shouldBe """{"creationTimestamp": 1}"""
+      ttlIndex.get("expireAfterSeconds") shouldBe BsonInt64(Constants.timeToLiveInSeconds)
+    }
+  }
+}


### PR DESCRIPTION
I've set the TTL to one month. It does mean Staging data will expire without perf tests runs but I don't see a way around it without using a silly value which makes TTL redundant or forgoing the TTL entirely, which is not recommended.

Screenshot of mongo TTL index:
<img width="446" alt="image" src="https://user-images.githubusercontent.com/29063729/228555484-075110a6-bf56-4258-99cf-4460357fe7a3.png">
